### PR TITLE
Switched to using postMessage timing under the hood

### DIFF
--- a/src/GamesRunnr.test.ts
+++ b/src/GamesRunnr.test.ts
@@ -179,7 +179,7 @@ describe("GamesRunnr", () => {
     });
 
     describe("setInterval", () => {
-        it("doesn't affect previously scheduled ticks", () => {
+        it("affects previously scheduled ticks", () => {
             // Arrange
             const games = [sinon.stub()];
             const interval = 10;
@@ -192,7 +192,7 @@ describe("GamesRunnr", () => {
             clock.tick(interval);
 
             // Assert
-            expect(games[0]).to.have.callCount(2);
+            expect(games[0]).to.have.callCount(1);
         });
 
         it("changes the schedule for future ticks", () => {

--- a/src/IGamesRunnr.ts
+++ b/src/IGamesRunnr.ts
@@ -1,18 +1,4 @@
-/**
- * Schedules a next tick.
- *
- * @param callback   Next tick to run.
- * @param timeout   How long to wait before calling the next tick.
- * @returns Cancellation token for the next tick.
- */
-export type ITickScheduler = (callback: () => void, timeout: number) => {};
-
-/**
- * Cancels running a next tick.
- *
- * @param handle   Cancellation token for a next tick.
- */
-export type ITickCanceller = (handle: {}) => void;
+import { IGameTiming } from "./timing";
 
 /**
  * Event hook for running or state change.
@@ -54,19 +40,14 @@ export interface IGamesRunnrSettings {
     games: IGame[];
 
     /**
-     * How often, in milliseconds, to execute games (by default, 1000 / 60).
+     * How often, in milliseconds, to execute games (by default, `1000 / 60`).
      */
     interval: number;
 
     /**
-     * Schedules a next tick (by default, setTimeout).
+     * Hooks for retrieving and scheduling timing.
      */
-    tickScheduler: ITickScheduler;
-
-    /**
-     * Cancels a next tick (by default, clearTimeout).
-     */
-    tickCanceller: ITickCanceller;
+    timing: IGameTiming;
 }
 
 /**

--- a/src/fakes.test.ts
+++ b/src/fakes.test.ts
@@ -1,14 +1,22 @@
 import * as lolex from "lolex";
 
 import { GamesRunnr } from "./GamesRunnr";
-import { IGamesRunnrSettings, ITickCanceller, ITickScheduler } from "./IGamesRunnr";
+import { IGamesRunnrSettings } from "./IGamesRunnr";
 
 export const stubGamesRunnr = (settings: Partial<IGamesRunnrSettings> = {}) => {
     const clock = lolex.createClock();
 
     const gamesRunner = new GamesRunnr({
-        tickCanceller: clock.clearTimeout as ITickCanceller,
-        tickScheduler: clock.setTimeout as ITickScheduler,
+        timing: {
+            cancelFrame: clock.clearTimeout,
+            getTimestamp: () => clock.now,
+            requestFrame: (callback) =>
+                clock.setTimeout(
+                    () => {
+                        callback(clock.now);
+                    },
+                    1),
+        },
         ...settings,
     });
 

--- a/src/timing.ts
+++ b/src/timing.ts
@@ -1,0 +1,94 @@
+/**
+ * Callback that can receive a timestamp from an `IRequestFrame`.
+ *
+ * @param timestamp   High resolution current timestamp.
+ */
+export type IFrameCallback = (timestamp: DOMHighResTimeStamp) => void;
+
+/**
+ * Cancels requesting a next frame.
+ *
+ * @param handle   Cancellation token for a next frame request.
+ */
+export type ICancelFrame = (handle: unknown) => void;
+
+/**
+ * @returns Current high-resolution timestamp.
+ */
+export type IGetTimestamp = () => DOMHighResTimeStamp;
+
+/**
+ * Schedules a tick for the next available frame.
+ *
+ * @param callback   Next tick to run.
+ * @returns Cancellation token for the next tick.
+ */
+export type IRequestFrame = (callback: IFrameCallback) => unknown;
+
+/**
+ * Hooks for retrieving and scheduling timing.
+ */
+export interface IGameTiming {
+    /**
+     * Cancels a next tick (by default, `cancelAnimationFrame`).
+     */
+    cancelFrame: ICancelFrame;
+
+    /**
+     * Gets a current timestamp (by default, `performance.now`).
+     */
+    getTimestamp: IGetTimestamp;
+
+    /**
+     * Schedules a next tick (by default, `requestAnimationFrame`).
+     */
+    requestFrame: IRequestFrame;
+}
+
+/**
+ * Creates hooks for retrieving and scheduling timing.
+ *
+ * @param getTimestamp   Gets a current timestamp.
+ * @returns Hooks for retrieving and scheduling timing.
+ */
+export const createGameTiming = (
+    getTimestamp: IGetTimestamp = () => performance.now(),
+): IGameTiming => {
+    const messagePrefix = `GamesRunnrMessageData${Math.random()}`;
+    const callbacks: { [i: string]: IFrameCallback | undefined } = {};
+    let callHandles = 0;
+
+    const cancelFrame: ICancelFrame = (handle: number) => {
+        delete callbacks[handle];
+    };
+
+    const onMessage = (event: MessageEvent) => {
+        if (
+            event.source !== window
+            || typeof event.data !== "string"
+            || event.data.indexOf(messagePrefix) === -1
+        ) {
+            return;
+        }
+
+        const callback = callbacks[event.data.substring(messagePrefix.length)];
+        if (!callback) {
+            return;
+        }
+
+        callback(getTimestamp());
+    };
+
+    const requestFrame: IRequestFrame = (callback: IFrameCallback) => {
+        const newHandle = `${callHandles += 1}`;
+
+        callbacks[newHandle] = callback;
+        window.postMessage(`${messagePrefix}${newHandle}`, "*");
+
+        return newHandle;
+    };
+
+    window.addEventListener("message", onMessage);
+
+    return { cancelFrame, getTimestamp, requestFrame };
+};

--- a/tslint.json
+++ b/tslint.json
@@ -6,8 +6,7 @@
         ]
     },
     "rules": {
-        "ban-types": false,
-        "no-magic-numbers": false,
-        "no-unsafe-any": false
+        "no-dynamic-delete": false,
+        "no-magic-numbers": false
     }
 }


### PR DESCRIPTION
### Summary

Continuously runs checks current timestamps as rapidly as possible. As soon as enough time has passed to satisfy the requested `interval`, the frame is executed.

Timestamps are adjusted so if a frame takes a few extra milliseconds, the next one will happen that much more quickly.

Fixes #68.
